### PR TITLE
🐛 Fix multiple calls during git rebase

### DIFF
--- a/src/commitcraft/__main__.py
+++ b/src/commitcraft/__main__.py
@@ -641,6 +641,11 @@ if [ "$HOOK_VERSION" != "$INSTALLED_VERSION" ] && [ "$INSTALLED_VERSION" != "unk
     echo "" >&2
 fi
 
+# Skip if rebase is in progress
+if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
+    exit 0
+fi
+
 # Only generate message for regular commits (not merge, squash, etc.)
 if [ -z "$COMMIT_SOURCE" ] || [ "$COMMIT_SOURCE" = "message" ]; then
     # Check if there are staged changes
@@ -749,6 +754,11 @@ if [ "$HOOK_VERSION" != "$INSTALLED_VERSION" ] && [ "$INSTALLED_VERSION" != "unk
     printf "\\033[1;33m⚠️  CommitCraft hook is outdated\\033[0m \\033[2m(hook: \\033[1;31m%s\\033[0m\\033[2m, installed: \\033[1;32m%s\\033[0m\\033[2m)\\033[0m\\n" "$HOOK_VERSION" "$INSTALLED_VERSION" >&2
     printf "   \\033[1;36mUpdate with:\\033[0m \\033[1;97m{update_command}\\033[0m\\n" >&2
     echo "" >&2
+fi
+
+# Skip if rebase is in progress
+if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
+    exit 0
 fi
 
 # Only generate message for regular commits (not merge, squash, etc.)


### PR DESCRIPTION
This pull request adds a safeguard to the commit hook script to prevent it from running during an active rebase operation. This helps avoid interfering with the rebase workflow and ensures the hook only executes for standard commit actions. No other changes are included.

* Added a check in the commit hook to exit early if a rebase is in progress by detecting `.git/rebase-merge` or `.git/rebase-apply` directories. [[1]](diffhunk://#diff-77d5bc8c73cd7f1ba263f0c8f05e8d41650d038d566148437aefbeecdd7d82e2R644-R648) [[2]](diffhunk://#diff-77d5bc8c73cd7f1ba263f0c8f05e8d41650d038d566148437aefbeecdd7d82e2R759-R763)