### PR TITLE
🚀 Add GitHub Actions for deployment and release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,51 @@
+name: Deploy MkDocs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs-material mkdocstrings mkdocs-include-markdown-plugin
+
+      - name: Build MkDocs site
+        run: mkdocs build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Build package
+        run: poetry build
+
+      - name: Publish to PyPI (Trusted Publisher)
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: CommitCraft
-site_url: https://github.com/Felix-Pedro/CommitCraft
+site_url: https://felix-pedro.github.io/CommitCraft/
 repo_url: https://github.com/Felix-Pedro/CommitCraft
 repo_name: Felix-Pedro/CommitCraft
 


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows for documentation deployment and PyPI publishing, and updates the documentation site URL. The main changes are the automation of documentation deployment to GitHub Pages using MkDocs, automated publishing to PyPI on release, and a correction to the documentation site URL.

**CI/CD Automation:**

* Added `.github/workflows/docs.yml` to automate building and deploying MkDocs documentation to GitHub Pages on pushes to `main` and manual triggers.
* Added `.github/workflows/release.yml` to automate building and publishing the package to PyPI when a new release is published.

**Documentation Configuration:**

* Updated `site_url` in `mkdocs.yml` to point to the correct GitHub Pages URL for the documentation site.