### PR TITLE
🔧 Migrate release workflow from Poetry to uv

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,11 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Install Poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Build package
-        run: poetry build
+        run: uv build
 
       - name: Publish to PyPI (Trusted Publisher)
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

Updates the automated PyPI release workflow to use **uv** instead of Poetry, completing the package manager migration started in v1.1.0.

## Changes

- ✅ Replace Poetry installation step with `astral-sh/setup-uv@v5` action
- ✅ Update build command from `poetry build` to `uv build`
- ✅ Maintain PyPI Trusted Publisher authentication (OIDC)
- ✅ Keep existing permissions configuration

## Workflow Behavior

**Trigger**: Automatically runs when a GitHub Release is published
**Actions**: 
1. Checkout code
2. Set up Python 3.x
3. Install uv
4. Build package with `uv build`
5. Publish to PyPI via Trusted Publisher

## Testing Plan

This will be tested when creating the v1.1.0 release. The workflow will:
- Build the distribution files (wheel + sdist)
- Publish to PyPI using OIDC authentication
- Complete in ~2-3 minutes

## Related

- Part of Poetry → uv migration (#30)
- Required for v1.1.0 release process
- Aligns with updated `pyproject.toml` and documentation

## Checklist

- [x] Workflow syntax validated
- [x] Uses official `astral-sh/setup-uv` action
- [x] Build command updated to `uv build`
- [x] Permissions block unchanged (OIDC compatible)
- [x] No breaking changes to workflow triggers