### PR TITLE
🐛 Fix PyPI README image display (v1.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to (or tries to) [Semantic Versioning](https://semver.o
 
 ---
 
+## [1.1.1] - 2026-01-26
+
+### Fixed
+
+- **PyPI README Display**: Fixed demo GIF not displaying on PyPI package page. Changed relative path `commitcraft-demo.gif` to absolute GitHub raw URL `https://raw.githubusercontent.com/Felix-Pedro/CommitCraft/main/commitcraft-demo.gif` so the image renders correctly on PyPI.
+
+---
+
 ## [1.1.0] - 2026-01-26
 
 ### Changed
@@ -148,7 +156,8 @@ and this project adheres to (or tries to) [Semantic Versioning](https://semver.o
 - GitMoji prompt.
 - Default system prompt.
 
-[unreleased]: https://github.com/Felix-Pedro/CommitCraft/compare/v1.1.0...HEAD
+[unreleased]: https://github.com/Felix-Pedro/CommitCraft/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/Felix-Pedro/CommitCraft/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/Felix-Pedro/CommitCraft/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/Felix-Pedro/CommitCraft/compare/v0.1.1...v1.0.0
 [0.1.1]: https://github.com/Felix-Pedro/CommitCraft/compare/v0.1.0...v0.1.1

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ![GitHub Repo stars](https://img.shields.io/github/stars/Felix-Pedro/CommitCraft?style=social)
 ![GitHub contributors](https://img.shields.io/github/contributors/Felix-Pedro/CommitCraft)
 
-[![CommitCraft Demo](commitcraft-demo.gif)](https://asciinema.org/a/SU2gpwni7jcAnxwd)
+[![CommitCraft Demo](https://raw.githubusercontent.com/Felix-Pedro/CommitCraft/main/commitcraft-demo.gif)](https://asciinema.org/a/SU2gpwni7jcAnxwd)
 
 CommitCraft is a tool designed to enhance your commit messages by leveraging Large Language Models (LLMs). It provides an intuitive interface that simplifies the process of generating better, more informative commit messages based on staged changes in your git repository.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "commitcraft"
-version = "1.1.0"
+version = "1.1.1"
 description = "A simple tool to use LLM and git diff to craft meaningful commit messages."
 authors = [{ name = "Felix-Pedro", email = "felix@auneria.com" }]
 license = "AGPL-3.0"


### PR DESCRIPTION
- Change demo GIF from relative path to GitHub raw URL
- Fixes image not displaying on PyPI package page
- Version bump to 1.1.1